### PR TITLE
Adding new required env variable of MMDB_LICENSE_KEY and removing thr…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM python:3.7.3-alpine
 
 RUN apk add --no-cache \
   bash \
+  wget \
   tcpdump \
   unzip \
   tar \
@@ -25,9 +26,8 @@ ARG GECKO_PATH="$GECKO_TAG/geckodriver-$GECKO_TAG-linux64.tar.gz"
 ARG BUP_TAG="2.0.1"
 ARG BUP_PATH="v$BUP_TAG/browserup-proxy-$BUP_TAG.zip"
 
-RUN apk add --no-cache --virtual builddeps build-base curl-dev wget linux-headers \
+RUN apk add --no-cache --virtual builddeps build-base curl-dev linux-headers \
     && pip install --no-cache-dir -r requirements.txt \
-    && wget -q https://geolite.maxmind.com/download/geoip/database/GeoLite2-ASN.tar.gz \
     && wget -q https://github.com/mozilla/geckodriver/releases/download/$GECKO_PATH \
     && wget -q https://github.com/browserup/browserup-proxy/releases/download/$BUP_PATH \
     && apk del builddeps

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ You'll need docker installed in order to run this container.
 * [macOS](https://docs.docker.com/mac/started/)
 * [Linux](https://docs.docker.com/linux/started/)
 
+You'll also need to [sign up for a GeoLite2 account](https://www.maxmind.com/en/geolite2/signup), and generate a license key. License keys can be generated free of charge and are used to authorize access to download MaxMind databases.
+
 ### Building From Source
 
 Run the following to build the Scouter container from source.
@@ -42,6 +44,7 @@ Coming soon!
 #### Required Variables
 
 * `SCOUTER_API_SECRET` - Specify the shared API secret to be used to authenticate every API call.
+* `MMDB_LICENSE_KEY` - Specify one of your valid GeoLite2 license keys to be used when pulling the latest GeoLite2-ASN.mmdb.
 
 #### Optional Variables
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ You'll need docker installed in order to run this container.
 * [macOS](https://docs.docker.com/mac/started/)
 * [Linux](https://docs.docker.com/linux/started/)
 
-You'll also need to [sign up for a GeoLite2 account](https://www.maxmind.com/en/geolite2/signup), and generate a license key. License keys can be generated free of charge and are used to authorize access to download MaxMind databases.
+You'll also need to [sign up for a GeoLite2 account](https://www.maxmind.com/en/geolite2/signup) and generate a license key. License keys can be generated free of charge and are used to authorize access to download MaxMind databases.
+
+The **GeoLite2-ASN** MaxMind database is used to translate source IP addresses in both the traceroute and dns_traceroute utilities into their associated Autonomous System Numbers.
 
 ### Building From Source
 

--- a/app.py
+++ b/app.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python3
-# pylint: disable=locally-disabled, missing-docstring, import-error
+# pylint: disable=locally-disabled, missing-docstring, import-error, invalid-name
 
 from secrets import token_hex
-import os
-import re
 import json
 from flask import Flask, jsonify, request, abort, make_response
 from waitress import serve
@@ -27,6 +25,7 @@ def check_auth_header():
         return abort(403)
     if token != CONFIG["api_secret"]:
         return abort(403)
+    return None
 
 
 @app.route("/api/v1.0/tests", methods=["POST"])

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -25,6 +25,16 @@ fi
 /bin/sed -i -e "s/{{SCOUTER_MAX_THREAD_COUNT}}/${SCOUTER_MAX_THREAD_COUNT}/g" config.cfg
 
 # -----------------------------------------------
+# Pull the latest GeoLite2-ASN MMDB
+# -----------------------------------------------
+echo "===> Pulling latest GeoLite2-ASN MMDB"
+if [[ ${MMDB_LICENSE_KEY:-""} == "" ]]; then
+  echo "ERROR: Missing ENV MMDB_LICENSE_KEY. Cannot proceed."
+  exit 1
+fi
+wget -q -O GeoLite2-ASN.tar.gz "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-ASN&license_key=$MMDB_LICENSE_KEY&suffix=tar.gz"
+
+# -----------------------------------------------
 # Configure Nginx
 # -----------------------------------------------
 echo "===> Configuring Nginx"


### PR DESCRIPTION
MaxMind recently restricted access to their GeoLite2 databases. It is now required that anyone wanting to access their databases must create an account with them. More information can be found [here](https://blog.maxmind.com/2019/12/18/significant-changes-to-accessing-and-using-geolite2-databases/)

I also noticed an issue with Scouter itself. The ICMP ping utility was rarely returning negative floats for the round-trip-times. I believe this issue is due to us utilizing threading to execute tests in parallel and the very slim chance that packets are being created with duplicate IDs. I've swapped out threading with multiprocessing and all usages of RandShort() in the ping utility have been replaced with os.getpid() as to guarantee that all packets are sent with a unique identifier. 