### PR TITLE
Fix traceroute & dns_traceroute's max_ttl option.

### DIFF
--- a/lib/utilities/dns.py
+++ b/lib/utilities/dns.py
@@ -184,7 +184,7 @@ def dns_traceroute(qname, **kwargs):
     }
     # Tell Scapy to NOT ignore the inner packet source. This is to avoid issues with NAT.
     conf.checkIPsrc = False
-    for ttl in range(constants.TRACE_MIN_TTL, constants.TRACE_MAX_TTL + 1):
+    for ttl in range(constants.TRACE_MIN_TTL, max_ttl + 1):
         hop_data = {
             "asn": None,
             "ttl": ttl,

--- a/lib/utilities/network.py
+++ b/lib/utilities/network.py
@@ -172,7 +172,7 @@ def traceroute(dst, **kwargs):
     )
     # Tell Scapy to NOT ignore the inner packet source. This is to avoid issues with NAT.
     conf.checkIPsrc = False
-    for ttl in range(constants.TRACE_MIN_TTL, constants.TRACE_MAX_TTL + 1):
+    for ttl in range(constants.TRACE_MIN_TTL, max_ttl + 1):
         hop_data = {
             "asn": None,
             "ttl": ttl,


### PR DESCRIPTION
Both the `traceroute` and `dns_traceroute` were not properly setting the `max_ttl` when set via the API.