### PR TITLE
Fix issue when id opt is passed to browser_request

### DIFF
--- a/lib/utilities/browser.py
+++ b/lib/utilities/browser.py
@@ -123,21 +123,23 @@ def _setup_proxy(headers):
     return proxy
 
 
-def browser_request(url, driver="chrome", headers=None):
+def browser_request(url, **kwargs):
     """Execute a browser emulated HTTP request.
 
     Attempt to load a provided webpage via a specified Browser, and return HAR data collected
     by a newly created proxy server.
 
     Args:
-        url     (str) : The webpage URL to attempt to load via the emulated browser.
-        driver  (str) : The browser driver to use in the request. Defaults to "chrome".
-        headers (dict): A key/value dict of HTTP request headers to inject. Defaults to None.
+        url       (str)  : The webpage URL to attempt to load via the emulated browser.
+        **driver  (str)  : The browser driver to use in the request. Defaults to "chrome".
+        **headers (dict) : A key/value dict of HTTP request headers to inject. Defaults to None.
 
     Returns:
         dict: Returns a dictionary object with test results.
 
     """
+    driver = kwargs.get("driver", "chrome").lower()
+    headers = kwargs.get("headers", None)
     headers = headers if headers is not None else {}
     failed = True
     proxy = _setup_proxy(headers)

--- a/lib/utilities/browser.py
+++ b/lib/utilities/browser.py
@@ -151,7 +151,7 @@ def browser_request(url, **kwargs):
         proxy.close()
         raise Exception(f"Provided driver of '{driver}' is not supported.")
     webdriver_.set_page_load_timeout(constants.WEBPAGE_LOAD_TIMEOUT)
-    har = {"child": []}
+    har = {"driver": driver, "child": []}
     try:
         webdriver_.get(url)
     except Exception as error:  # pylint: disable=broad-except


### PR DESCRIPTION
Passing the `id` option to `browser_request` results in the following error:

```
{
  "is_running": false,
  "receipt": "42b2284077916412df554ab7b853065e",
  "results": {
    "browser_request": [
      {
        "failed": true,
        "id": "browser_example",
        "message": "browser_request() got an unexpected keyword argument 'id'",
        "result": {}
      }
    ]
  }
}
```

This is due to the uniqueness of the `browser_request` utility as it's the only utility to not use `**kwargs`.