### PR TITLE
Reverting execute_tests func to use a daemon.

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Coming soon!
 #### Optional Variables
 
 * `SCOUTER_MAX_TEST_COUNT` - Specify the maximum number of individual tests in a single test payload. Defaults to **10**.
-* `SCOUTER_MAX_THREAD_COUNT` - Specify the maximum number of parallel threads to be used in test execution. Defaults to **10**.
+* `SCOUTER_MAX_PROCESS_COUNT` - Specify the maximum number of parallel processes to be used in test execution. Defaults to **10**.
 * `API_PORT` - Specify the port that Nginx will be listening on. Defaults to **8000**.
 * `UWSGI_WORKERS` - Specify the number of Uwsgi worker processes to use. Defaults to **3**.
 * `UWSGI_CACHE_ITEMS` - Specify the maximum number of Uwsgi cache items. Defaults to **100**.

--- a/app.py
+++ b/app.py
@@ -47,7 +47,7 @@ def create_tests():
     # Generate the client's receipt and pass the test payload to a background thread to be executed.
     receipt = token_hex(16)
     uwsgi.cache_set(receipt, "{}", 600, "receipts")
-    execute_tests(receipt, payload, CONFIG["max_thread_count"])
+    execute_tests(receipt, payload, CONFIG["max_process_count"])
     return jsonify({"receipt": receipt})
 
 

--- a/config.cfg
+++ b/config.cfg
@@ -1,4 +1,4 @@
 [Scouter]
 api_secret = {{SCOUTER_API_SECRET}}
 max_test_count = {{SCOUTER_MAX_TEST_COUNT}}
-max_thread_count = {{SCOUTER_MAX_THREAD_COUNT}}
+max_process_count = {{SCOUTER_MAX_PROCESS_COUNT}}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@
 # Assign defaults if variable not set
 # -----------------------------------------------
 export SCOUTER_MAX_TEST_COUNT=${SCOUTER_MAX_TEST_COUNT:=10}
-export SCOUTER_MAX_THREAD_COUNT=${SCOUTER_MAX_THREAD_COUNT:=10}
+export SCOUTER_MAX_PROCESS_COUNT=${SCOUTER_MAX_PROCESS_COUNT:=10}
 export API_PORT=${API_PORT:=8000}
 export UWSGI_WORKERS=${UWSGI_WORKERS:=3}
 export UWSGI_CACHE_ITEMS=${UWSGI_CACHE_ITEMS:=100}
@@ -22,7 +22,7 @@ if [[ ${SCOUTER_API_SECRET:-""} == "" ]]; then
 fi
 /bin/sed -i -e "s/{{SCOUTER_API_SECRET}}/${SCOUTER_API_SECRET}/g" config.cfg
 /bin/sed -i -e "s/{{SCOUTER_MAX_TEST_COUNT}}/${SCOUTER_MAX_TEST_COUNT}/g" config.cfg
-/bin/sed -i -e "s/{{SCOUTER_MAX_THREAD_COUNT}}/${SCOUTER_MAX_THREAD_COUNT}/g" config.cfg
+/bin/sed -i -e "s/{{SCOUTER_MAX_PROCESS_COUNT}}/${SCOUTER_MAX_PROCESS_COUNT}/g" config.cfg
 
 # -----------------------------------------------
 # Pull the latest GeoLite2-ASN MMDB

--- a/lib/config.py
+++ b/lib/config.py
@@ -25,7 +25,7 @@ def get_config_options(**kwargs):
     try:
         config_options["api_secret"] = config.get("Scouter", "api_secret")
         config_options["max_test_count"] = int(config.get("Scouter", "max_test_count"))
-        config_options["max_thread_count"] = int(config.get("Scouter", "max_thread_count"))
+        config_options["max_process_count"] = int(config.get("Scouter", "max_process_count"))
     except (configparser.NoSectionError, configparser.NoOptionError) as error:
         raise ConfigError(error)
     return config_options


### PR DESCRIPTION
Reverting the use of multiprocessing in the execute_tests function back 
to threading due to blocking of incoming POST requests breaking the 
asyncronous nature of Scouter.

Also updating verbiage in various locations including the README to reflect the uses of processes over threads.